### PR TITLE
build: use correct version depending on workflow type

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -37,7 +37,7 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
-          ref: ${{ github.event.inputs.version }}
+          ref: ${{ (github.event.inputs || inputs).version }}
 
       - name: Set up Python
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
Fixes: #38