### PR TITLE
fix: add missing VirtualBox apt key and repository

### DIFF
--- a/ansible/roles/workstations/tasks/install-dev-tools.yml
+++ b/ansible/roles/workstations/tasks/install-dev-tools.yml
@@ -111,6 +111,18 @@
 
 - name: Install VirtualBox
   block:
+    - name: Install VirtualBox apt key
+      ansible.builtin.apt_key:
+        url: https://www.virtualbox.org/download/oracle_vbox_2016.asc
+
+    - name: Install VirtualBox apt repository
+      ansible.builtin.apt_repository:
+        repo: >
+          deb
+          https://download.virtualbox.org/virtualbox/debian
+          {{ ansible_distribution_release }}
+          contrib
+
     - name: Accept VirtualBox license
       ansible.builtin.debconf:
         name: virtualbox-ext-pack


### PR DESCRIPTION
Relates to: #81 