### PR TITLE
fix: separate VirtualBox installation from extensions

### DIFF
--- a/ansible/roles/workstations/tasks/install-dev-tools.yml
+++ b/ansible/roles/workstations/tasks/install-dev-tools.yml
@@ -72,14 +72,14 @@
 
 - name: Install Terraform
   block:
-    - name: Install HashiCorp apt key
+    - name: Add HashiCorp apt key
       ansible.builtin.apt_key:
         url: https://apt.releases.hashicorp.com/gpg
 
-    - name: Install HashiCorp apt repository
+    - name: Add HashiCorp apt repository
       ansible.builtin.apt_repository:
         repo: >
-          deb [arch=amd64]
+          deb
           https://apt.releases.hashicorp.com
           {{ ansible_distribution_release }}
           main
@@ -110,15 +110,16 @@
       - postman
 
 - name: Install VirtualBox
+  tags: test
   block:
-    - name: Install VirtualBox apt key
+    - name: Add VirtualBox apt key
       ansible.builtin.apt_key:
         url: https://www.virtualbox.org/download/oracle_vbox_2016.asc
 
-    - name: Install VirtualBox apt repository
+    - name: Add VirtualBox apt repository
       ansible.builtin.apt_repository:
         repo: >
-          deb [arch=amd64]
+          deb
           https://download.virtualbox.org/virtualbox/debian
           {{ ansible_distribution_release }}
           contrib

--- a/ansible/roles/workstations/tasks/install-dev-tools.yml
+++ b/ansible/roles/workstations/tasks/install-dev-tools.yml
@@ -110,7 +110,6 @@
       - postman
 
 - name: Install VirtualBox
-  tags: test
   block:
     - name: Add VirtualBox apt key
       ansible.builtin.apt_key:
@@ -131,7 +130,7 @@
         value: "true"
         vtype: select
 
-    # virtualbox needs to be installed before the extensions otherwise the
+    # VirtualBox needs to be installed before the extensions otherwise the
     # package dependencies will conflict
     - name: Install VirtualBox
       ansible.builtin.package:

--- a/ansible/roles/workstations/tasks/install-dev-tools.yml
+++ b/ansible/roles/workstations/tasks/install-dev-tools.yml
@@ -118,7 +118,7 @@
     - name: Install VirtualBox apt repository
       ansible.builtin.apt_repository:
         repo: >
-          deb
+          deb [arch=amd64]
           https://download.virtualbox.org/virtualbox/debian
           {{ ansible_distribution_release }}
           contrib
@@ -130,10 +130,15 @@
         value: "true"
         vtype: select
 
+    # virtualbox needs to be installed before the extensions otherwise the
+    # package dependencies will conflict
     - name: Install VirtualBox
       ansible.builtin.package:
+        name: virtualbox
+
+    - name: Install VirtualBox extensions
+      ansible.builtin.package:
         name:
-          - virtualbox
           - virtualbox-ext-pack
           - virtualbox-guest-utils
 


### PR DESCRIPTION
Relates to: #81 