### PR TITLE
fix: install fd from apt

### DIFF
--- a/ansible/roles/workstations/tasks/install-utilities.yml
+++ b/ansible/roles/workstations/tasks/install-utilities.yml
@@ -146,13 +146,18 @@
     group: aki
 
 - name: Install fd
-  ansible.builtin.apt:
-    deb:
-      "https://github.com/sharkdp/fd/releases/download/\
-      {{ fd_version }}/\
-      fd_\
-      {{ fd_version | regex_replace('v(.+)', '\\1') }}_\
-      amd64.deb"
+  block:
+    - name: Install fd
+      ansible.builtin.package:
+        name: fd-find
+
+    - name: Create fd->fdfind symlink
+      ansible.builtin.file:
+        src: /usr/bin/fdfind
+        dest: /home/aki/.local/bin/fd
+        owner: aki
+        group: aki
+        state: link
 
 - name: Install git
   block:

--- a/ansible/roles/workstations/templates/users/aki/zsh/functions.zsh.j2
+++ b/ansible/roles/workstations/templates/users/aki/zsh/functions.zsh.j2
@@ -123,7 +123,7 @@ function cdp() {
   local project_dir
 
   project_dir=$(
-    fd '.git$' ~/Projects --type d --unrestricted --exec echo "{//}" |
+    fd '.git$' ~/Projects --type d --hidden --no-ignore --exec echo "{//}" |
       fzfp --query "${*:-}"
   )
 


### PR DESCRIPTION
This ensures no conflicts with the already installed apt package in Pop OS.
Unfortunately, it also means using the outdated 8.3.1 version, which has
different behaviour for `--unrestricted`.

See: https://github.com/sharkdp/fd/releases/tag/v8.4.0

Relates to: #46 