### PR TITLE
fix: increase timeout for slow server

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -11,5 +11,10 @@ vault_identity_list = dev@vault-password-dev.txt, prod@vault-password-prod.sh
 
 strategy=free
 
+# server-pi is quite slow which causes frequent timeouts with the message
+# "Timeout (12s) waiting for privilege escalation prompt: ".
+# Increasing the timeout to 30 seconds should help prevent this issue.
+timeout = 30
+
 [connection]
 pipelining=True


### PR DESCRIPTION
server-pi is quite slow which causes frequent timeouts with the message
"Timeout (12s) waiting for privilege escalation prompt: ".
Increasing the timeout to 30 seconds should help prevent this issue.

Relates to: #164 