### PR TITLE
fix: integrate correctly with CODEOWNERS

### DIFF
--- a/.github/workflows/build-pr-target.yml
+++ b/.github/workflows/build-pr-target.yml
@@ -74,7 +74,7 @@ jobs:
             token=${{ secrets.AKI_APPROVE_PRS_TOKEN }}
           fi
 
-          echo "token=$token" >> $GITHUB_OUTPUT
+          echo "token=$token" >> "$GITHUB_OUTPUT"
 
       - name: Approve PR
         # yamllint disable-line rule:line-length

--- a/.github/workflows/build-pr-target.yml
+++ b/.github/workflows/build-pr-target.yml
@@ -62,11 +62,22 @@ jobs:
   approve-pr:
     name: Approve PR
     runs-on: ubuntu-latest
+    if: github.actor == 'AkiKanellis' || github.actor == 'aki-bot[bot]'
 
     steps:
+      - name: Get token
+        id: get-token
+        run: |
+          if [[ ${{ github.actor }} == "AkiKanellis" ]]; then
+            token=${{ secrets.GITHUB_TOKEN }}
+          else
+            token=${{ secrets.AKI_APPROVE_PRS_TOKEN }}
+          fi
+
+          echo "token=$token" >> $GITHUB_OUTPUT
+
       - name: Approve PR
         # yamllint disable-line rule:line-length
         uses: hmarr/auto-approve-action@de8ae18c173c131e182d4adf2c874d8d2308a85b # tag=v3.1.0
-        if: github.actor == 'akikanellis' || github.actor == 'aki-bot[bot]'
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.get-token.outputs.token }}

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,1 +1,1 @@
-* @akikanellis @aki-bot[bot]
+* @akikanellis


### PR DESCRIPTION
CODEOWNERS does not support adding the `github-actions` bot into it, but it supports adding other bots. But for a personal GitHub account, bots cannot be added as collaborators. This effectively means, that the only actual CODEOWNER with the power to approve PRs is the account owner, in this case `akikanellis`. Therefore, this account is the only one that can approve PRs, to achieve that, we use a PAT.

Fixes: #185

<!-- markdownlint-disable MD041 -->