### PR TITLE
fix: use `prefix` instead of `bin`

### DIFF
--- a/ansible/roles/all/templates/users/aki/zsh/functions.zsh.j2
+++ b/ansible/roles/all/templates/users/aki/zsh/functions.zsh.j2
@@ -46,7 +46,7 @@ function update() {
 
   if command_exists npm; then
     echo "Updating npm..."
-    npm update --location=global
+    npm update --global
     echo "npm updated!"
   fi
 

--- a/ansible/roles/common/tasks/asdf.yml
+++ b/ansible/roles/common/tasks/asdf.yml
@@ -95,16 +95,16 @@
     pip_executable: "{{ which_pip.stdout }}"
   when: "'python' in asdf_plugins_names"
 
-- name: Discover "aki" user npm binaries directory
+- name: Discover "aki" user npm prefix
   become_user: aki
   ansible.builtin.command:
     cmd: >
-      zsh -c "source ~/.asdf/asdf.sh && direnv exec ~ npm bin --location=global"
-  register: npm_bin_result
+      zsh -c "source ~/.asdf/asdf.sh && direnv exec ~ npm prefix --global"
+  register: npm_prefix_result
   changed_when: false
   when: "'nodejs' in asdf_plugins_names"
 
 - name: Set npm binaries directory
   ansible.builtin.set_fact:
-    npm_binaries_dir: "{{ npm_bin_result.stdout }}"
+    npm_binaries_dir: "{{ npm_prefix_result.stdout }}/bin"
   when: "'nodejs' in asdf_plugins_names"

--- a/ansible/roles/common/tasks/npm.yml
+++ b/ansible/roles/common/tasks/npm.yml
@@ -8,6 +8,6 @@
   ansible.builtin.command:
     cmd: >
       zsh -c "source ~/.asdf/asdf.sh &&
-      direnv exec ~ npm install --location=global {{ item }}"
+      direnv exec ~ npm install --global {{ item }}"
     creates: "{{ npm_binaries_dir }}/{{ item }}"
   loop: "{{ package_names }}"


### PR DESCRIPTION
`npm bin` was removed as part of npm [v9.0.0](https://github.com/npm/cli/releases/tag/v9.0.0).