### PR TITLE
fix: install starship from edge channel

### DIFF
--- a/ansible/roles/all/tasks/install-utilities.yml
+++ b/ansible/roles/all/tasks/install-utilities.yml
@@ -51,8 +51,12 @@
     name:
       - btop
       - httpie
-      - starship
       - yq
+
+- name: Install starship
+  community.general.snap:
+    name: starship
+    channel: edge
 
 - name: Install bat
   block:


### PR DESCRIPTION
Starship moved to an edge-only release on Snap.

See: https://github.com/starship/starship/issues/4954