### PR TITLE
fix: downgrade community.general to 6.4.0

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,6 +4,8 @@ collections:
     version: 1.4.0
   - name: ansible.utils
     version: 2.7.0
+  - name: community.general
+    version: 6.4.0
   - name: devsec.hardening
     version: 8.4.0
 


### PR DESCRIPTION
Version 6.5.0 introduces a bug where keys must already exist
when using dconf.

See:

  - https://github.com/ansible-collections/community.general/blob/stable-6/CHANGELOG.rst
  - https://github.com/ansible-collections/community.general/pull/6049
  - https://github.com/ansible-collections/community.general/issues/6271