### PR TITLE
build: simplify deployments

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -65,8 +65,9 @@ jobs:
     name: Deploy to prod
     needs: release
     if: needs.release.outputs.release-published == 'true'
-    uses: ./.github/workflows/deploy-to-prod.yml
+    uses: ./.github/workflows/deploy.yml
     with:
+      environment: prod
       version: v${{ needs.release.outputs.release-version }}
     secrets:
       ANSIBLE_SSH_PRIVATE_KEY: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -27,7 +27,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [lint, test]
     concurrency: ${{ github.workflow }}-release
 
     outputs:

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -19,10 +19,14 @@ jobs:
   lint:
     name: Lint
     uses: ./.github/workflows/lint.yml
+    with:
+      continue-on-error: true
 
   test:
     name: Test
     uses: ./.github/workflows/test.yml
+    with:
+      continue-on-error: true
 
   release:
     name: Release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,13 @@
 ---
-name: Deploy to Prod
+name: Deploy
 
 "on":
   workflow_call:
     inputs:
+      environment:
+        type: string
+        description: Deployment environment
+        required: true
       version:
         type: string
         description: Deployment version
@@ -17,6 +21,10 @@ name: Deploy to Prod
         required: true
   workflow_dispatch:
     inputs:
+      environment:
+        type: environment
+        description: Deployment environment
+        required: true
       version:
         type: string
         description: Deployment version
@@ -25,7 +33,8 @@ name: Deploy to Prod
         description: Extra ansible-playbook options
         required: false
 
-concurrency: ${{ github.workflow }}
+concurrency:
+  ${{ github.workflow }}-${{ (github.event.inputs || inputs).environment }}
 
 env:
   # renovate: datasource=pypi depName=ansible-core
@@ -35,10 +44,10 @@ env:
   NETADDR_VERSION: 0.8.0
 
 jobs:
-  deploy-to-prod:
-    name: Deploy to prod
+  deploy:
+    name: Deploy
     runs-on: self-hosted
-    environment: prod
+    environment: ${{ (github.event.inputs || inputs).environment }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ name: Lint
   workflow_call:
     inputs:
       continue-on-error:
-        type: string
+        type: boolean
         description: Allow a workflow run to pass when this workflow fails
         required: false
         default: false
@@ -14,7 +14,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    continue-on-error: ${{ fromJSON(inputs.continue-on-error) }}
+    continue-on-error: ${{ inputs.continue-on-error }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,18 @@ name: Lint
 
 "on":
   workflow_call:
+    inputs:
+      continue-on-error:
+        type: string
+        description: Allow a workflow run to pass when this workflow fails
+        required: false
+        default: false
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    continue-on-error: ${{ fromJSON(inputs.continue-on-error) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,18 @@ name: Test
 
 "on":
   workflow_call:
+    inputs:
+      continue-on-error:
+        type: string
+        description: Allow a workflow run to pass when this workflow fails
+        required: false
+        default: false
 
 jobs:
   test:
     name: Test
     runs-on: macos-12
+    continue-on-error: ${{ fromJSON(inputs.continue-on-error) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Test
   workflow_call:
     inputs:
       continue-on-error:
-        type: string
+        type: boolean
         description: Allow a workflow run to pass when this workflow fails
         required: false
         default: false
@@ -14,7 +14,7 @@ jobs:
   test:
     name: Test
     runs-on: macos-12
-    continue-on-error: ${{ fromJSON(inputs.continue-on-error) }}
+    continue-on-error: ${{ inputs.continue-on-error }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This mandates passing in the environment on deployments and also
simplifies them by not requiring `test` and `lint` since we have enabled
the GitHub setting "Require branches to be up to date before merging".

See: https://github.com/actions/runner/issues/1492#issuecomment-1031669824