### PR TITLE
fix: set compose HTTP timeout to 120

### DIFF
--- a/.github/linters/.ansible-lint.yml
+++ b/.github/linters/.ansible-lint.yml
@@ -1,4 +1,9 @@
 ---
 use_default_rules: true
 parseable: true
-skip_list: [yaml]
+skip_list:
+  # Temporarily disabled due to outdated ansible-lint in Super-Linter.
+  # Will re-enable after switching to MegaLinter.
+  - schema[tasks]
+  # YAML linting is handled by yamllint
+  - yaml

--- a/ansible/roles/servers/tasks/create-docker-apps.yml
+++ b/ansible/roles/servers/tasks/create-docker-apps.yml
@@ -96,6 +96,10 @@
       up
       --detach
       --remove-orphans
+  environment:
+    # Compose frequently times out in some apps due to a lack of processing
+    # power in the server and a default timeout of 60.
+    COMPOSE_HTTP_TIMEOUT: 120
   loop: "{{ apps }}"
   register: docker_compose_up_result
   changed_when: >


### PR DESCRIPTION
Compose frequently times out in some apps due to a lack of processing
power in the server and a default timeout of 60.