### PR TITLE
fix: allow netdata to write in config directory

### DIFF
--- a/ansible/roles/servers/templates/server-nas/docker/apps/monitoring/compose.yml.j2
+++ b/ansible/roles/servers/templates/server-nas/docker/apps/monitoring/compose.yml.j2
@@ -8,7 +8,7 @@ services:
 
       DOCKER_HOST: docker-socket-proxy:2375
     volumes:
-      - "{{ volumes_directory }}/netdata:/etc/netdata:ro"
+      - "{{ volumes_directory }}/netdata:/etc/netdata"
 
       - /etc/group:/host/etc/group:ro
       - /etc/passwd:/host/etc/passwd:ro

--- a/ansible/roles/servers/templates/server-pi/docker/apps/monitoring/compose.yml.j2
+++ b/ansible/roles/servers/templates/server-pi/docker/apps/monitoring/compose.yml.j2
@@ -10,7 +10,7 @@ services:
 
       DOCKER_HOST: docker-socket-proxy:2375
     volumes:
-      - "{{ volumes_directory }}/netdata:/etc/netdata:ro"
+      - "{{ volumes_directory }}/netdata:/etc/netdata"
 
       - /etc/group:/host/etc/group:ro
       - /etc/passwd:/host/etc/passwd:ro


### PR DESCRIPTION
Updates on netdata might require config migrations performed by the
process. This fix allows the migration to go ahead.